### PR TITLE
Add bottom sheet for orders

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,5 +66,6 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+    implementation(libs.material3)
 
 }

--- a/app/src/main/java/com/example/createplanetapp/DBHelper.kt
+++ b/app/src/main/java/com/example/createplanetapp/DBHelper.kt
@@ -93,15 +93,15 @@ class DBHelper(context: Context, factory: SQLiteDatabase.CursorFactory?) :
      * @param fStatus - строка ("true" или "false")
      * @param oStatus - строка ("true" или "false")
      */
-    fun getRecords(items: List<ItemsViewModel>, fStatus: String, oStatus: String) : ArrayList<ItemsViewModel> {
+    /* Function searches for favorite matching */
+    fun getFavoriteRecords(items: List<ItemsViewModel>) : ArrayList<ItemsViewModel> {
         val db = this.readableDatabase
 
         val favoriteItems = ArrayList<ItemsViewModel>()
 
         val cursorTable : Cursor = db.rawQuery("""
             SELECT * FROM $TABLE_NAME
-            WHERE $FAVORITE_STATUS = '$fStatus'
-            AND $ORDERED_STATUS = '$oStatus'
+            WHERE $FAVORITE_STATUS = 'true'
         """.trimIndent(), null)
 
         cursorTable.use { cursor ->
@@ -117,6 +117,32 @@ class DBHelper(context: Context, factory: SQLiteDatabase.CursorFactory?) :
         }
 
         return favoriteItems
+    }
+
+    /* Function searches for ordered matching */
+    fun getOrderedRecords(items: List<ItemsViewModel>) : ArrayList<ItemsViewModel> {
+        val db = this.readableDatabase
+
+        val orderedItems = ArrayList<ItemsViewModel>()
+
+        val cursorTable : Cursor = db.rawQuery("""
+            SELECT * FROM $TABLE_NAME
+            WHERE $ORDERED_STATUS = 'true'
+        """.trimIndent(), null)
+
+        cursorTable.use { cursor ->
+            if (cursor.moveToFirst()) {
+                do {
+                    items.forEach {
+                        if(it.title == cursor.getString(1)) {
+                            orderedItems.add(it)
+                        }
+                    }
+                } while(cursor.moveToNext())
+            }
+        }
+
+        return orderedItems
     }
 
     /** Function shows is element with title $name favorite or not */

--- a/app/src/main/java/com/example/createplanetapp/GlobalData.kt
+++ b/app/src/main/java/com/example/createplanetapp/GlobalData.kt
@@ -3,21 +3,16 @@ package com.example.createplanetapp
 import android.content.Context
 
 /**
- * USAGE:
+ * This class contains all parsed items from R.raw.* in `ArrayList<ItemViewModel>` data type
  *
- *   val `<name>` = GlobalData.items`[<index>]`
+ * `GlobalData.initialize` - initial parsing
  *
- *   `<name>` - your own name for variable which would be in use
- *
- *   `<index>` should be chose if needed:
-- default: list of all excursions, no boundaries by type
-- 0: po_gorodu.csv
-- 1: zagorodnie.csv
+ * `GlobalData.items` - returns all items
  */
 object GlobalData {
-    private var _items: List<ArrayList<ItemsViewModel>>? = null  // Item — ваша модель данных
+    private var _items: ArrayList<ItemsViewModel>? = null  // Item — ваша модель данных
 
-    val items: List<ArrayList<ItemsViewModel>>
+    val items: ArrayList<ItemsViewModel>
         get() = _items ?: throw IllegalStateException("Данные не загружены. Вызовите GlobalData.initialize()")
 
     fun initialize(context: Context) {
@@ -25,10 +20,10 @@ object GlobalData {
             _items = parseCsv(context)
         }
     }
-    private fun parseCsv(context: Context): List<ArrayList<ItemsViewModel>> {
-        val items = mutableListOf<ArrayList<ItemsViewModel>>()
-        items.add(csvParser(context.resources, R.raw.po_gorodu))
-        items.add(csvParser(context.resources, R.raw.zagorodnie))
+    private fun parseCsv(context: Context): ArrayList<ItemsViewModel> {
+        val items = ArrayList<ItemsViewModel>()
+        items += csvParser(context.resources, R.raw.po_gorodu)
+        items += csvParser(context.resources, R.raw.zagorodnie)
         return items
     }
 }

--- a/app/src/main/java/com/example/createplanetapp/MainScreen.kt
+++ b/app/src/main/java/com/example/createplanetapp/MainScreen.kt
@@ -87,8 +87,8 @@ fun ContentScreen(modifier: Modifier = Modifier, selectedIndex: Int, catalogStat
     when (selectedIndex) {
         0 -> HomePage()
         1 -> CatalogPage(catalogState = catalogState)
-        2 -> FavoritesPage()
-        3 -> OrdersPage()
+        2 -> FavoritesPage(authViewModel = authViewModel)
+        3 -> OrdersPage(authViewModel = authViewModel)
         4 -> ProfilePage(authViewModel = authViewModel)
     }
 }

--- a/app/src/main/java/com/example/createplanetapp/pages/CatalogPage.kt
+++ b/app/src/main/java/com/example/createplanetapp/pages/CatalogPage.kt
@@ -441,7 +441,6 @@ fun CatalogItem(
     // var isPaid by rememberSaveable(title) { mutableStateOf(dbHelper.isPaid(title)) }
     //в бд добавить поле Оплачено/Не оплачено + функцию на проверку этого поля по аналогии с isFavorite
 
-
     val navController = LocalNavController.current
 
     Box(

--- a/app/src/main/java/com/example/createplanetapp/pages/FavoritesPage.kt
+++ b/app/src/main/java/com/example/createplanetapp/pages/FavoritesPage.kt
@@ -1,5 +1,6 @@
 package com.example.createplanetapp.pages
 
+import android.provider.Settings
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -33,7 +34,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberAsyncImagePainter
+import com.example.createplanetapp.AuthViewModel
 import com.example.createplanetapp.DBHelper
+import com.example.createplanetapp.GlobalData
 import com.example.createplanetapp.ItemsViewModel
 import com.example.createplanetapp.R
 import com.example.createplanetapp.csvParser
@@ -47,22 +50,14 @@ import kotlin.collections.plus
 
 @Composable
 fun FavoritesPage(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    authViewModel: AuthViewModel
 ) {
     val context = LocalContext.current
     val dbHelper = remember { DBHelper(context, null) }
     var favoriteItems by remember { mutableStateOf<List<ItemsViewModel>>(emptyList()) }
 
-    fun loadFavorites() {
-        val itemsPoGorodu = csvParser(context.resources, R.raw.po_gorodu)
-        val itemsZagorodnie = csvParser(context.resources, R.raw.zagorodnie)
-        val allItems = itemsPoGorodu + itemsZagorodnie
-
-        favoriteItems = dbHelper.getRecords(allItems, "true", "false")
-        favoriteItems += dbHelper.getRecords(allItems, "true", "true")
-    }
-
-    loadFavorites()
+    favoriteItems = dbHelper.getFavoriteRecords(GlobalData.items)
 
     Column(
         modifier = modifier
@@ -96,7 +91,7 @@ fun FavoritesPage(
                     items(favoriteItems) { item ->
                         FavoriteItem(
                             item = item,
-                            onFavoriteChanged = { loadFavorites() }
+                            onFavoriteChanged = { favoriteItems = dbHelper.getFavoriteRecords(GlobalData.items) }
                         )
                     }
                 }

--- a/app/src/main/java/com/example/createplanetapp/pages/ItemMainPage.kt
+++ b/app/src/main/java/com/example/createplanetapp/pages/ItemMainPage.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -27,7 +28,9 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -52,14 +55,17 @@ import com.example.createplanetapp.kazimirSemibold
 import com.example.createplanetapp.ui.theme.blueColor
 import com.example.createplanetapp.ui.theme.mainColor
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ItemMainPage(title: String, onClick: () -> Unit) {
     val item: ItemsViewModel = GlobalData.items
-        .flatten()
         .first { it.title == title }
 
     val context = LocalContext.current
     val dbHelper = remember { DBHelper(context, null) }
+
+    val bottomSheetState = rememberModalBottomSheetState()
+    var showBottomSheet by remember { mutableStateOf(false) }
 
     var isTextExpanded by remember { mutableStateOf(false) }
     var isWayExpanded by remember { mutableStateOf(false) }
@@ -92,6 +98,64 @@ fun ItemMainPage(title: String, onClick: () -> Unit) {
     }
 
     /*ЗАНОВО ПЕРЕДЕЛАТЬ ДИНАМИЧЕСКОЕ ИЗМЕНЕНИЕ ЦЕНЫ*/
+
+    if (showBottomSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showBottomSheet = false },
+            sheetState = bottomSheetState
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+            ) {
+                Text(
+                    text = "Бронирование",
+                    fontFamily = kazimirBold,
+                    fontSize = 16.sp,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                Text("""1
+                    |2
+                    |3
+                    |4
+                    |5
+                    |6
+                    |7
+                    |8
+                    |9
+                    |10
+                    |
+                """.trimMargin())
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Button(
+                    onClick = {
+                        dbHelper.setOrderedStatus(item.title, "true")
+                        Toast.makeText(context, "Бронь оформлена!", Toast.LENGTH_LONG).show()
+                    },
+                    modifier = Modifier
+                        .padding(top = 5.dp)
+                        .height(33.dp)
+                        .width(150.dp)
+                        .align(Alignment.CenterHorizontally),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = blueColor,
+                        disabledContentColor = mainColor
+                    )
+                ) {
+                    Text(
+                        text = "Оплатить",
+                        fontSize = 14.sp,
+                        fontFamily = kazimirRegular,
+                        color = Color.White
+                    )
+                }
+
+            }
+        }
+    }
 
     Box(
         modifier = Modifier
@@ -266,10 +330,7 @@ fun ItemMainPage(title: String, onClick: () -> Unit) {
             //Booking button
             Box(modifier = Modifier.fillMaxSize()) {
                 Button(
-                    onClick = {
-                        dbHelper.setOrderedStatus(title, "true")
-                        Toast.makeText(context, "Бронь оформлена!", Toast.LENGTH_LONG).show()
-                              },
+                    onClick = { showBottomSheet = true },
                     modifier = Modifier
                         .padding(start = 16.dp, top = 20.dp, bottom = 30.dp)
                         .align(Alignment.BottomCenter),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ espressoCore = "3.5.1"
 lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.09.00"
+material3 = "1.3.2"
 navigationCommonAndroid = "2.9.1"
 navigationComposeAndroid = "2.9.1"
 firebaseDatabase = "22.0.0"
@@ -44,6 +45,7 @@ androidx-navigation-compose-android = { group = "androidx.navigation", name = "n
 firebase-database = { group = "com.google.firebase", name = "firebase-database", version.ref = "firebaseDatabase" }
 firebase-auth = { group = "com.google.firebase", name = "firebase-auth", version.ref = "firebaseAuth" }
 androidx-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "runtimeLivedata" }
+material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Changes:
DBHelper - getRecords methos was divided at two methods: getOrderedRecords & getFavoriteRecords
GlobalData - rebase data type of functions & methods
Orders & Favorite - GlobalData methods were implemented
Orders - now has bottom sheet for order details
ItemMainPage - now has bottom sheet for booking items

TODO: payment process at ItemMainPage